### PR TITLE
Add slash to closing <h1> tag in slides

### DIFF
--- a/slides.html
+++ b/slides.html
@@ -498,7 +498,7 @@ Lorem ipsum dolor sit amet, consectetur adipiscing elit. Duis semper congue lacu
 
           HTML _tags_ describe the content inside of them to the web browser.
           ```xml
-          <h1>This tag describes a heading<h1>
+          <h1>This tag describes a heading</h1>
           <p>This tag is for paragraphs.</p>
           ```
 


### PR DESCRIPTION
The closing `<h1>` tag on slide 46 was missing the slash. 

<img width="1341" alt="Screen Shot 2019-05-21 at 1 14 44 PM" src="https://user-images.githubusercontent.com/10404392/58120268-7949ca00-7bca-11e9-81e6-c03df467c64e.png">
